### PR TITLE
When a sub-frame cannot scroll, focus the top frame.

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -267,7 +267,12 @@ Scroller =
     unless CoreScroller.wouldNotInitiateScroll()
       element = findScrollableElement activatedElement, direction, amount, factor
       elementAmount = factor * getDimension element, direction, amount
-      CoreScroller.scroll element, direction, elementAmount, continuous
+      if not DomUtils.isTopFrame() and element == document.documentElement
+        # If this is not the top frame, and we can't scroll it, then bounce the focus to the top frame.
+        chrome.runtime.sendMessage
+          handler: "sendMessageToFrames", message: {name: "runInTopFrame", sourceFrameId: frameId, registryEntry: command: "mainFrame"}
+      else
+        CoreScroller.scroll element, direction, elementAmount, continuous
 
   scrollTo: (direction, pos) ->
     activatedElement ||= (getScrollingElement() and firstScrollableElement()) or getScrollingElement()


### PR DESCRIPTION
When the focus is in a sub-frame, and `j` or `k` will not scroll that
frame, then bounce the focus to the main/top frame.

Use case... Twitter.  Many tweets on https://twitter.com are actually in
frames.  When you click on the link in the tweet, the focus ends up in
that frame, so `j`/`k` scrolling of the main/top frame stops working.
You have to `gF` to get the focus back in the main frame before you can
proceed to the next tweet.

This is a really ugly UX.  The user really shouldn't have to be thinking
about frames in this context.

Here, when the tweet frame fails to scroll, the focus is bounced out to
the top from, so `j`/`k` immediately scrolls that frame.

This is similar (but not identical) to the behaviour when the focus is
in a scrollable input (say).  When we reach the end of the input, we
next scroll the containing element.

Issues:

- The UX here is great for Twitter, but how would it work on other
  sites?
- Is the test `element == document.documentElement` the correct way of
  testing that we've run out of possibly scrollable elements within a
  sub-frame?
- We really should be focusing the parent frame (not the top frame).